### PR TITLE
Stop hardcoding data zac

### DIFF
--- a/constants/ChaptersList.json
+++ b/constants/ChaptersList.json
@@ -1,0 +1,42 @@
+[
+  {
+    "key": "Chapter 1",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 2",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 3",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 4",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 5",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 6",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 7",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 8",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 9",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+  {
+    "key": "Chapter 10",
+    "subtext": "Lorem Ipsum Dolor Sit Amet"
+  },
+]

--- a/constants/CommentariesList.json
+++ b/constants/CommentariesList.json
@@ -1,0 +1,71 @@
+[
+  {
+    "title": "THE FORGOTTEN WAY",
+    "data": [
+      {
+        "key": 1,
+        "name": "Core Truth #1: Lorem Ipsum",
+        "subtext": "8 minutes, 38 seconds",
+        "image": "https://images.unsplash.com/photo-1541832069-e4f383392e1d?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=a561f6a5179df29e8729877d4ff80b32&auto=format&fit=crop&w=500&q=60"
+      },
+      {
+        "key": 2,
+        "name": "Core Truth #2: Lorem Ipsum",
+        "subtext": "5 minutes, 22 seconds",
+        "image": "https://images.unsplash.com/photo-1541796484625-7f5bcba550cc?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac759f3f244b417ca48e7f15b8e0b7d8&auto=format&fit=crop&w=500&q=60"
+      },
+      {
+        "key": 3,
+        "name": "Core Truth #3: Lorem Ipsum",
+        "subtext": "4 minutes, 29 seconds",
+        "image": "https://images.unsplash.com/photo-1541789094913-f3809a8f3ba5?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=6ba555c8bb03ffabb86e6ecf9ec4243c&auto=format&fit=crop&w=500&q=60"
+      },
+      {
+        "key": 4,
+        "name": "Core Truth #4: Lorem Ipsum",
+        "subtext": "5 minutes, 32 seconds",
+        "image": "https://images.unsplash.com/photo-1541746951956-4f27df54f02b?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=027b183a2e7e5c8cb657862b34db5530&auto=format&fit=crop&w=500&q=60"
+      },
+      {
+        "key": 5,
+        "name": "Core Truth #5: Lorem Ipsum",
+        "subtext": "6 minutes, 52 seconds",
+        "image": "https://images.unsplash.com/photo-1541753231552-fa0b6f0c4d7c?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2887fd5cf1d3eae72545fe3d8cdd5a04&auto=format&fit=crop&w=500&q=60"
+      },
+    ]
+  },
+  {
+    "title": "MEDITATIONS",
+    "data": [
+      {
+        "key": 1,
+        "name": "Practicing Mindfulness",
+        "subtext": "9 minutes, 34 seconds",
+        "image": "https://images.unsplash.com/photo-1541664480066-ae01cda3bc69?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=1d3aa7477394b86b8289beffc12174c8&auto=format&fit=crop&w=500&q=60"
+      },
+    ]
+  },
+  {
+    "title": "PODCASTS",
+    "data": [
+      {
+        "key": 1,
+        "name": "Aubrey Marcus Podcast with Ted Dekker",
+        "subtext": "1 hour, 25 minutes",
+        "image": "https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60"
+      },
+      {
+        "key": 2,
+        "name": "The Joe Rogan Experience with Ted Dekker",
+        "subtext": "2 hours, 58 minutes",
+        "image": "https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60"
+      },
+      {
+        "key": 3,
+        "name": "The Tim Ferris Show with Ted Dekker",
+        "subtext": "3 hours, 9 minutes",
+        "image": "https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60" 
+      },
+    ]
+  },
+]

--- a/constants/CommentariesList.json
+++ b/constants/CommentariesList.json
@@ -64,7 +64,7 @@
         "key": 3,
         "name": "The Tim Ferris Show with Ted Dekker",
         "subtext": "3 hours, 9 minutes",
-        "image": "https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60" 
+        "image": "https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60"
       },
     ]
   },

--- a/reducers/ChaptersListReducer.js
+++ b/reducers/ChaptersListReducer.js
@@ -1,0 +1,3 @@
+import data from '../constants/ChaptersList.json';
+
+export default () => data;

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -1,0 +1,6 @@
+import { combineReducers } from 'redux';
+import ChaptersListReducer from './ChaptersListReducer';
+
+export default combineReducers({
+  chaptersList: ChaptersListReducer,
+});

--- a/screens/ChaptersScreen.js
+++ b/screens/ChaptersScreen.js
@@ -1,74 +1,62 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { ScrollView, StyleSheet, FlatList, Text, Platform, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import PlayerFooter from '../components/PlayerFooter';
+import data from '../constants/ChaptersList.json';
 
-export default class ChaptersScreen extends React.Component {
+export default class ChaptersScreen extends Component {
   static navigationOptions = {
     title: 'CHAPTERS',
   };
 
+//Grabs the data for the list from ChaptersList.json
   constructor(props) {
     super(props);
     this.state = {
-      data: [
-        { key: 'Chapter 1', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 2', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 3', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 4', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 5', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 6', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 7', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 8', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 9', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-        { key: 'Chapter 10', subtext: 'Lorem Ipsum Dolor Sit Amet' },
-      ]
+      data,
     };
   }
-
 
   render() {
     return (
       <View style={styles.container}>
-      <ScrollView style={styles.scrollView}>
-        <FlatList
-          contentContainerStyle={styles.flatList}
-          data={this.state.data}
+        <ScrollView style={styles.scrollView}>
+          <FlatList
+            contentContainerStyle={styles.flatList}
+            data={this.state.data}
 
-          /* Function below adds conditional formatting to chapters
-          based on position in the list */
-          renderItem={({ item, index }) => {
-            if (index < 2) { // First two use itemComplete styling
-              return (
-                <View style={[styles.chapterTile, styles.itemComplete]}>
+            /* Function below adds conditional formatting to chapters
+            based on position in the list */
+            renderItem={({ item, index }) => {
+              if (index < 2) { // First two use itemComplete styling
+                return (
+                  <View style={[styles.chapterTile, styles.itemComplete]}>
+                    <View style={styles.item}>
+                      <Text style={styles.chapterText}>{ item.key }</Text>;
+                      <Text style={styles.chapterSubtext}>{ item.subtext }</Text>;
+                    </View>
+                    <View style={styles.icon}>
+                      <Ionicons name="md-checkmark-circle" size={32} color="white" />
+                    </View>
+                  </View>
+                );
+              }
+              return ( // else use item styling
+                <View style={styles.chapterTile}>
                   <View style={styles.item}>
                     <Text style={styles.chapterText}>{ item.key }</Text>;
                     <Text style={styles.chapterSubtext}>{ item.subtext }</Text>;
                   </View>
                   <View style={styles.icon}>
-                    <Ionicons name="md-checkmark-circle" size={32} color="white" />
+                    <Ionicons name="ios-play" size={32} color="white" />
                   </View>
                 </View>
               );
             }
-            return ( // else use item styling
-              <View style={styles.chapterTile}>
-                <View style={styles.item}>
-                  <Text style={styles.chapterText}>{ item.key }</Text>;
-                  <Text style={styles.chapterSubtext}>{ item.subtext }</Text>;
-                </View>
-                <View style={styles.icon}>
-                  <Ionicons name="ios-play" size={32} color="white" />
-                </View>
-              </View>
-            );
           }
-        }
-        />
-      </ScrollView>
-
+          />
+        </ScrollView>
       <View style={{ flex: 0.09 }}><PlayerFooter /></View>
-
     </View>
     );
   }

--- a/screens/CommentariesScreen.js
+++ b/screens/CommentariesScreen.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Image, StyleSheet, Text, SectionList, TouchableOpacity, View } from 'react-native';
 import PlayerFooter from '../components/PlayerFooter';
-
-/* Changed title from 'app.json' to 'Commentaries'
-  * We should go back and update all the file names and classes too */
+import SectionLabel from '../components/SectionLabel';
+import data from '../constants/CommentariesList.json';
 
 export default class CommentariesScreen extends React.Component {
   static navigationOptions = {
@@ -13,35 +12,9 @@ export default class CommentariesScreen extends React.Component {
 constructor(props) {
   super(props);
   this.state = {
-    data: [
-      {
-        title: 'THE FORGOTTEN WAY',
-        data: [
-          { key: 1, name: 'Core Truth #1: Lorem Ipsum', subtext: '8 minutes, 38 seconds', image: 'https://images.unsplash.com/photo-1541832069-e4f383392e1d?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=a561f6a5179df29e8729877d4ff80b32&auto=format&fit=crop&w=500&q=60' },
-          { key: 2, name: 'Core Truth #2: Lorem Ipsum', subtext: '5 minutes, 22 seconds', image: 'https://images.unsplash.com/photo-1541796484625-7f5bcba550cc?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac759f3f244b417ca48e7f15b8e0b7d8&auto=format&fit=crop&w=500&q=60' },
-          { key: 3, name: 'Core Truth #3: Lorem Ipsum', subtext: '4 minutes, 29 seconds', image: 'https://images.unsplash.com/photo-1541789094913-f3809a8f3ba5?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=6ba555c8bb03ffabb86e6ecf9ec4243c&auto=format&fit=crop&w=500&q=60' },
-          { key: 4, name: 'Core Truth #4: Lorem Ipsum', subtext: '5 minutes, 32 seconds', image: 'https://images.unsplash.com/photo-1541746951956-4f27df54f02b?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=027b183a2e7e5c8cb657862b34db5530&auto=format&fit=crop&w=500&q=60' },
-          { key: 5, name: 'Core Truth #5: Lorem Ipsum', subtext: '6 minutes, 52 seconds', image: 'https://images.unsplash.com/photo-1541753231552-fa0b6f0c4d7c?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2887fd5cf1d3eae72545fe3d8cdd5a04&auto=format&fit=crop&w=500&q=60' },
-        ]
-      },
-      {
-        title: 'MEDITATIONS',
-        data: [
-          { key: 1, name: 'Practicing Mindfulness', subtext: '9 minutes, 34 seconds', image: 'https://images.unsplash.com/photo-1541664480066-ae01cda3bc69?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=1d3aa7477394b86b8289beffc12174c8&auto=format&fit=crop&w=500&q=60' },
-        ]
-      },
-      {
-        title: 'PODCASTS',
-        data: [
-          { key: 1, name: 'Aubrey Marcus Podcast with Ted Dekker', subtext: '1 hour, 25 minutes', image: 'https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60' },
-          { key: 2, name: 'The Joe Rogan Experience with Ted Dekker', subtext: '2 hours, 58 minutes', image: 'https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60' },
-          { key: 3, name: 'The Tim Ferris Show with Ted Dekker', subtext: '3 hours, 9 minutes', image: 'https://images.unsplash.com/photo-1484704849700-f032a568e944?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=04c4af64629678d376f21fd9bd05229f&auto=format&fit=crop&w=500&q=60' },
-        ]
-      },
-    ]
+    data, //grabs data from CommentariesList.json
   };
 }
-
 
  render() {
     return (
@@ -51,7 +24,7 @@ constructor(props) {
             sections={this.state.data}
             stickySectionHeadersEnabled={false}
             renderSectionHeader={({ section }) =>
-            <Text style={styles.sectionHeader}>{section.title}</Text>}
+            <SectionLabel labelText={section.title} />}
 
             renderItem={({ item }) =>
             <View style={[styles.sectionListContainer, styles.contentContainer]}>
@@ -99,15 +72,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginBottom: 6
   },
-  sectionHeader: {
-    paddingTop: 20,
-    paddingLeft: 20,
-    paddingRight: 10,
-    paddingBottom: 8,
-    fontSize: 12,
-    fontFamily: 'lato-black',
-    color: 'rgba(96,100,109, 1)',
-  },
   item: {
     padding: 10,
     fontSize: 18,
@@ -117,7 +81,7 @@ const styles = StyleSheet.create({
     width: 80,
     height: 60,
     borderRadius: 5,
-    marginLeft: 20,
+    marginLeft: 25,
   },
   name: {
     fontSize: 16,


### PR DESCRIPTION
CommentariesScreen.js and ChaptersScreen.js were unnecessarily long due to hardcoding List data into the screen component. I split out the data from those pages into separate JSON files for importing. It saves about 30 lines of code per file and makes our screen files tidier.

I started out trying to pass the data in via Redux, but ended up getting stuck and finding a different method for now. That's why you'll see a couple new reducer files.

![giphy 7](https://user-images.githubusercontent.com/18668152/48975848-639e8200-f037-11e8-8232-a911725eeabb.gif)
